### PR TITLE
udpate shared workflows

### DIFF
--- a/.github/workflows/build-push-create-pr.yaml
+++ b/.github/workflows/build-push-create-pr.yaml
@@ -18,7 +18,7 @@ jobs:
       contents: write
       pull-requests: write
       repository-projects: write
-    uses: cal-icor/shared-workflows/.github/workflows/build-push-create-pr.yaml@0.1.2
+    uses: cal-icor/shared-workflows/.github/workflows/build-push-create-pr.yaml@0.2.1
     with:
       image: ${{ vars.IMAGE}}
       hub: ${{ vars.HUB }}

--- a/.github/workflows/build-test-image.yaml
+++ b/.github/workflows/build-test-image.yaml
@@ -12,4 +12,4 @@ on:
 
 jobs:
   test-build:
-    uses: cal-icor/shared-workflows/.github/workflows/build-test-image.yaml@0.1.2
+    uses: cal-icor/shared-workflows/.github/workflows/build-test-image.yaml@0.2.1

--- a/apt.txt
+++ b/apt.txt
@@ -28,9 +28,6 @@ net-tools
 htop
 tree
 
-# for timing builds
-time
-
 # for jupyter-tree-download, #3979
 zip
 


### PR DESCRIPTION
this pr also updates the shared workflows to use the latest tag (https://github.com/cal-icor/shared-workflows/releases/tag/0.2.1) which uses the new repo2docker as per https://github.com/cal-icor/shared-workflows/pull/6