### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @shaneknapp @sean-morris


### PR DESCRIPTION
Adds a CODEOWNERS file under `.github/` setting @shaneknapp and @sean-morris as default reviewers, matching cal-icor-hubs. No workflow changes needed: the build workflows already ignore `.github/**` in their paths-ignore stanzas, so this file won't trigger image rebuilds.