### PR TITLE
bump python packages to latest for 3.13.*

### DIFF
--- a/.github/workflows/build-push-create-pr.yaml
+++ b/.github/workflows/build-push-create-pr.yaml
@@ -20,7 +20,7 @@ jobs:
       contents: write
       pull-requests: write
       repository-projects: write
-    uses: cal-icor/shared-workflows/.github/workflows/build-push-create-pr.yaml@0.4.0
+    uses: cal-icor/shared-workflows/.github/workflows/build-push-create-pr.yaml@0.4.2
     with:
       image: ${{ vars.IMAGE}}
       hub: ${{ vars.HUB }}

--- a/.github/workflows/build-test-image.yaml
+++ b/.github/workflows/build-test-image.yaml
@@ -12,4 +12,4 @@ on:
 
 jobs:
   test-build:
-    uses: cal-icor/shared-workflows/.github/workflows/build-test-image.yaml@0.4.0
+    uses: cal-icor/shared-workflows/.github/workflows/build-test-image.yaml@0.4.2

--- a/.github/workflows/yaml-lint.yaml
+++ b/.github/workflows/yaml-lint.yaml
@@ -4,4 +4,4 @@ on:
 
 jobs:
   lint:
-    uses: cal-icor/shared-workflows/.github/workflows/yaml-lint.yaml@0.4.0
+    uses: cal-icor/shared-workflows/.github/workflows/yaml-lint.yaml@0.4.2

--- a/environment.yml
+++ b/environment.yml
@@ -10,50 +10,51 @@ dependencies:
   # also squelches the attrs version warning emitted when running the notebook tests
   - attrs==26.1.0
   - gh-scoped-creds==4.1
-  - git==2.53.0
-  - ipython==9.9.0
-  - jupyter-resource-usage=1.2.0
+  - git==2.54.0
+  - ipython==9.14.1
+  - jupyter-resource-usage=1.2.1
+  # pinned to match the deployed hub image's jupyterhub version
   - jupyterhub==5.4.4
-  - jupyterlab==4.5.8
+  - jupyterlab==4.5.9
   - jupyter-archive==3.4.0
-  - jupyter_server==2.17.0
-  - jupyterlab-git==0.51.2
+  - jupyter_server==2.20.0
+  - jupyterlab-git==0.54.0
   - jupyterlab_rise==0.43.1
-  - jupytext==1.16.6
-  - notebook==7.5.6
+  - jupytext==1.19.3
+  - notebook==7.5.7
   - python==3.13.*
-  - pip==25.1.1
-  - quarto==1.8.27
-  - regex==2025.11.3
-  - sqlite==3.51.1
+  - pip==26.1.2
+  - regex==2026.5.9
+  - sqlite==3.53.2
 
   # vscode
-  - code-server==4.106.2
+  - code-server==4.124.2
   - jupyter-vscode-proxy==0.7
-  - jupyter-server-proxy==4.4.0
+  - jupyter-server-proxy==4.5.0
 
   # data science
   - datascience==0.18.1
-  - matplotlib==3.10.3
-  - numpy==2.3.5
-  - geopandas==1.1.0
+  - matplotlib==3.11.0
+  - numpy==2.4.6
+  - geopandas==1.1.3
   - geopy==2.4.1
   - openpyxl==3.1.5
-  - pandas==2.3.0
-  - plotly==6.1.2
-  - scikit-learn==1.7.0
-  - scipy==1.15.2
+  - pandas==3.0.3
+  - plotly==6.8.0
+  - pytorch==2.12.0
+  - scikit-learn==1.9.0
+  - scipy==1.17.1
   - seaborn==0.13.2
-  - statsmodels==0.14.4
+  - statsmodels==0.14.6
   - sympy==1.14.0
 
   # pip installed packages, conda is preferred
   - pip:
     # useful for debugging python package issues
-    - pip-tree==4.0.0
-    - pipdeptree==2.28.0
+    - pip-tree==5.0.0
+    - pipdeptree==3.1.0
 
-    - jupysql==0.10.15
-    - nbconvert[webpdf]==7.16.6
-    - otter-grader==6.1.3
+    - jupysql==0.11.1
+    - nbconvert[webpdf]==7.17.1
+    - otter-grader==6.1.6
     - nbgitpuller==1.3.0


### PR DESCRIPTION
this is to bring this image (and then the downstream `workshop-user-image`) to have identical python package versions as done with the `base-user-image` and `csumb-user-image` per these PRs:

https://github.com/cal-icor/base-user-image/pull/139
https://github.com/cal-icor/csumb-user-image/pull/93