### PR TITLE
 bump notebook and jupyterlab to latest

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -16,13 +16,13 @@ dependencies:
   - jupyter-resource-usage=1.2.1
   # pinned to match the deployed hub image's jupyterhub version
   - jupyterhub==5.5.0
-  - jupyterlab==4.6.1
+  - jupyterlab==4.6.2
   - jupyter-archive==3.4.0
   - jupyter_server==2.20.0
   - jupyterlab-git==0.54.0
   - jupyterlab_rise==0.43.1
   - jupytext==1.19.3
-  - notebook==7.6.0
+  - notebook==7.6.1
   - python==3.13.*
   - pip==26.1.2
   - regex==2026.5.9


### PR DESCRIPTION
ref: https://github.com/cal-icor/cal-icor-hubs/issues/1018

this bumps jupyterlab to 4.6.2 and notebook to 7.6.1