### PR TITLE
 bump jupyterhub, notebook and jupyterlab to latest

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -15,14 +15,14 @@ dependencies:
   - ipython==9.15.0
   - jupyter-resource-usage=1.2.1
   # pinned to match the deployed hub image's jupyterhub version
-  - jupyterhub==5.5.0
-  - jupyterlab==4.6.2
+  - jupyterhub==5.5.1
+  - jupyterlab==4.6.3
   - jupyter-archive==3.4.0
   - jupyter_server==2.20.0
   - jupyterlab-git==0.54.0
   - jupyterlab_rise==0.43.1
   - jupytext==1.19.3
-  - notebook==7.6.1
+  - notebook==7.6.2
   - python==3.13.*
   - pip==26.1.2
   - regex==2026.5.9


### PR DESCRIPTION
ref: https://github.com/cal-icor/cal-icor-hubs/issues/1018 https://github.com/cal-icor/cal-icor-hubs/issues/1045

this bumps jupyterhub to 5.5.1, jupyterlab to 4.6.2 and notebook to 7.6.1